### PR TITLE
reset text color after usage message

### DIFF
--- a/bin/tus
+++ b/bin/tus
@@ -23,7 +23,7 @@ function warning { local message="${1}"
 
 function usage { local message="${1}";
   [ -n "${message}" ] \
-    && echo -e "\033[0;31m➤\033[0m \033[1m${message}\033[21m"
+    && echo -e "\033[0;31m➤\033[0m \033[1m${message}\033[0m"
   cat <<-EOTXT
 
 Usage:


### PR DESCRIPTION
fix: helptext after usage message is printed with underlined blue text

example: usage message is "No file given"

```
$ tus
➤ No file given

Usage:
  tus [options] file
...
```
